### PR TITLE
Notification of upgrades with tray icon

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -1112,6 +1112,7 @@
             this.minimizeNotifyIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("minimizeNotifyIcon.Icon")));
             this.minimizeNotifyIcon.Text = "CKAN";
             this.minimizeNotifyIcon.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.minimizeNotifyIcon_MouseDoubleClick);
+            this.minimizeNotifyIcon.BalloonTipClicked += new System.EventHandler(this.minimizeNotifyIcon_BalloonTipClicked);
             // 
             // minimizedContextMenuStrip
             // 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -364,7 +364,7 @@ namespace CKAN
             }
 
             CheckTrayState();
-            RunRefreshTimer();
+            InitRefreshTimer();
 
             m_UpdateRepoWorker = new BackgroundWorker { WorkerReportsProgress = false, WorkerSupportsCancellation = true };
 


### PR DESCRIPTION
KSP-CKAN/CKAN#2565 is really cool, nice job finding that API!
This pull request fixes some problems with that one and harvests some of its low-hanging fruit.

## Fixes

- Create the timer unconditionally so it will work if the user enables it for the first time in this session
- Fix the crash on first loading the settings (side effect of previous bullet point)
- Consolidate the timer setting+starting logic in one place, called by the other place

## Feature

If you enable the tray icon, then when the registry is refreshed (including when CKAN is minimized), you'll get a notification popup if there are upgrades to install:

![image](https://user-images.githubusercontent.com/1559108/47960407-2a07c780-dff3-11e8-979e-09fb72b02875.png)

Clicking it un-minimizes CKAN, selects the available upgrades, and jumps to the install screen.