### PR TITLE
Don't set maximized config when minimizing

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1134,9 +1134,13 @@ namespace CKAN
             {
                 minimizeNotifyIcon.Visible = true;
 
-                if (minimizeToTray && WindowState == FormWindowState.Minimized)
+                if (WindowState == FormWindowState.Minimized)
                 {
-                    Hide();
+                    if (minimizeToTray)
+                    {
+                        // Remove our taskbar entry
+                        Hide();
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Currently if minimizeToTray is false, minimizing a maximized window and then unminimizing it via the tray icon results in a non-maximized window.

Now this is fixed.